### PR TITLE
Add mock response for remote select types.

### DIFF
--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -36,7 +36,8 @@ const devWebpackConfig = merge(baseWebpackConfig, {
     quiet: true, // necessary for FriendlyErrorsPlugin
     watchOptions: {
       poll: config.dev.poll,
-    }
+    },
+    before: config.dev.before
   },
   plugins: [
     new webpack.DefinePlugin({

--- a/config/index.js
+++ b/config/index.js
@@ -3,6 +3,7 @@
 // see http://vuejs-templates.github.io/webpack for documentation.
 
 const path = require('path')
+const mockResponce = require('./mock-response.js')
 
 module.exports = {
   dev: {
@@ -10,15 +11,11 @@ module.exports = {
     // Paths
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
-    proxyTable: {
-      '/api': {
-        target: 'http://localhost:8080'
-      }
-    },
+    proxyTable: {},
 
     // Various Dev Server settings
     host: 'localhost', // can be overwritten by process.env.HOST
-    port: 3000, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
+    port: 8080, // can be overwritten by process.env.PORT, if port is in use, a free one will be determined
     autoOpenBrowser: false,
     errorOverlay: true,
     notifyOnErrors: true,
@@ -49,7 +46,12 @@ module.exports = {
     // (https://github.com/webpack/css-loader#sourcemaps)
     // In our experience, they generally work as expected,
     // just be aware of this issue when enabling this option.
-    cssSourceMap: false
+    cssSourceMap: false,
+    before (app) {
+      app.get('/api/v1/it_emx_datatypes_TypeTestRef', function (req, res) {
+        res.json(mockResponce)
+      })
+    }
   },
 
   build: {

--- a/config/mock-response.js
+++ b/config/mock-response.js
@@ -1,0 +1,62 @@
+module.exports = {
+  'href': '/api/v1/it_emx_datatypes_TypeTestRef',
+  'meta': {
+    'href': '/api/v1/it_emx_datatypes_TypeTestRef/meta',
+    'hrefCollection': '/api/v1/it_emx_datatypes_TypeTestRef',
+    'name': 'it_emx_datatypes_TypeTestRef',
+    'label': 'TypeTestRef',
+    'description': 'MOLGENIS Data types test ref entity',
+    'attributes': {
+      'value': {
+        'href': '/api/v1/it_emx_datatypes_TypeTestRef/meta/value'
+      },
+      'label': {
+        'href': '/api/v1/it_emx_datatypes_TypeTestRef/meta/label'
+      }
+    },
+    'labelAttribute': 'label',
+    'idAttribute': 'value',
+    'lookupAttributes': [
+      'value',
+      'label'
+    ],
+    'isAbstract': false,
+    'languageCode': 'en',
+    'writable': true
+  },
+  'start': 0,
+  'num': 100,
+  'total': 6,
+  'items': [
+    {
+      'href': '/api/v1/it_emx_datatypes_TypeTestRef/ref1',
+      'value': 'ref1',
+      'label': 'label1'
+    },
+    {
+      'href': '/api/v1/it_emx_datatypes_TypeTestRef/ref2',
+      'value': 'ref2',
+      'label': 'label2'
+    },
+    {
+      'href': '/api/v1/it_emx_datatypes_TypeTestRef/ref3',
+      'value': 'ref3',
+      'label': 'label3'
+    },
+    {
+      'href': '/api/v1/it_emx_datatypes_TypeTestRef/ref4',
+      'value': 'ref4',
+      'label': 'label4'
+    },
+    {
+      'href': '/api/v1/it_emx_datatypes_TypeTestRef/ref5',
+      'value': 'ref5',
+      'label': 'label5'
+    },
+    {
+      'href': '/api/v1/it_emx_datatypes_TypeTestRef/ref6',
+      'value': 'ref6',
+      'label': 'label6'
+    }
+  ]
+}

--- a/test/e2e/specs/FormDemoTest.js
+++ b/test/e2e/specs/FormDemoTest.js
@@ -12,7 +12,7 @@ module.exports = {
       .url(devServer)
       .waitForElementVisible('#form-demo', 5000)
       .assert.elementPresent('form')
-      .assert.elementCount('input', 20)
+      .assert.elementCount('input', 32)
       .end()
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,8 +3,8 @@
 
 
 "@molgenis/molgenis-api-client@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.0.tgz#66cdcca5c4a2e0b413be7aef27cd5559ffdcb2e2"
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.1.tgz#32cfb162fbe6c6ccf1b249cb4bb9005f19fbc34d"
   dependencies:
     babel-runtime "^6.11.6"
     form-data "^2.3.1"
@@ -1131,8 +1131,8 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     electron-to-chromium "^1.2.7"
 
 browserslist@^2.1.2, browserslist@^2.10.2:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.2.tgz#0838eec4b3db2d860cee13bf6c0691e7e8133822"
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.0.tgz#50350d6873a82ebe0f3ae5483658c571ae5f9d7d"
   dependencies:
     caniuse-lite "^1.0.30000784"
     electron-to-chromium "^1.3.30"
@@ -1237,12 +1237,12 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000784"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000784.tgz#1be95012d9489c7719074f81aee57dbdffe6361b"
+  version "1.0.30000787"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000787.tgz#ca07a281be536a88bd7fac96ba895f3cf53f811b"
 
 caniuse-lite@^1.0.30000784:
-  version "1.0.30000784"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000784.tgz#129ced74e9a1280a441880b6cd2bce30ef59e6c0"
+  version "1.0.30000787"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000787.tgz#a76c4fa1d6ac00640447ec83c1e7c6b33dd615c5"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1315,8 +1315,8 @@ chownr@^1.0.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
 chromedriver@^2.27.2:
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-2.34.0.tgz#f5f51c4f213c7cfec0c9d7d6fa76e19e308417aa"
+  version "2.34.1"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-2.34.1.tgz#4ceff1b1ef785fb41bd75029167e94b50bd77844"
   dependencies:
     del "^3.0.0"
     extract-zip "^1.6.5"
@@ -2279,10 +2279,6 @@ es6-map@^0.1.3, es6-map@^0.1.5:
     event-emitter "~0.3.5"
 
 es6-promise@^4.0.3, es6-promise@^4.0.5, es6-promise@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.2.tgz#f722d7769af88bd33bc13ec6605e1f92966b82d9"
-
-es6-promise@^4.0.5, es6-promise@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.2.tgz#f722d7769af88bd33bc13ec6605e1f92966b82d9"
 
@@ -4889,8 +4885,10 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.0.0, p-limit@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.2.0.tgz#0e92b6bedcb59f022c13d0f1949dc82d15909f1c"
+  dependencies:
+    p-try "^1.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -4901,6 +4899,10 @@ p-locate@^2.0.0:
 p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
 pac-proxy-agent@1:
   version "1.1.0"
@@ -5227,8 +5229,8 @@ postcss-load-plugins@^2.3.0:
     object-assign "^4.1.0"
 
 postcss-loader@^2.0.8:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.0.9.tgz#001fdf7bfeeb159405ee61d1bb8e59b528dbd309"
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.0.10.tgz#090db0540140bd56a7a7f717c41bc29aeef4c674"
   dependencies:
     loader-utils "^1.1.0"
     postcss "^6.0.0"


### PR DESCRIPTION
- Use dev server to supply mock response
- Bump api version ( yarn upgrade) to allow default json response handeling